### PR TITLE
Update page title to match official YSWS name

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,7 @@ export default function App() {
     <Router
       root={(props) => (
         <MetaProvider>
-          <Title>Overflow: None</Title>
+          <Title>overflow: hidden;</Title>
           <Suspense>{props.children}</Suspense>
         </MetaProvider>
       )}


### PR DESCRIPTION
I updated the page title from "Overflow: None" to "overflow: hidden;" (which seems to be the actual name of this YSWS).

Here's the error it fixes:

<img width="365" height="118" alt="image" src="https://github.com/user-attachments/assets/d2cc8290-736b-43ac-8435-d9190976cc29" />

Feel free to merge or simply make the change locally if it's easier :P